### PR TITLE
Feature: Event Store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "interactor-rails"
 gem "jbuilder", "~> 2.5"
 gem "jquery-rails"
 gem "turbolinks", "~> 5"
+gem "rails_event_store"
 
 gem "blockchain-api"
 gem "coinbase"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    aggregate_root (0.18.2)
+      activesupport (>= 3.0)
     arel (8.0.0)
     awesome_print (1.8.0)
     bcrypt (3.1.11)
@@ -199,6 +201,17 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_event_store (0.18.2)
+      activejob (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      aggregate_root (= 0.18.2)
+      rails_event_store_active_record (= 0.18.2)
+      ruby_event_store (= 0.18.2)
+    rails_event_store_active_record (0.18.2)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      ruby_event_store (= 0.18.2)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -254,6 +267,7 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.7.0)
+    ruby_event_store (0.18.2)
     safe_yaml (1.0.4)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
@@ -362,6 +376,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.1.0)
   rails-controller-testing
+  rails_event_store
   redis-rails
   rqrcode-with-patches (~> 0.5.4)
   rspec-rails

--- a/app/command/base.rb
+++ b/app/command/base.rb
@@ -1,0 +1,19 @@
+module Command
+  class Base
+    include ActiveModel::Model
+    include ActiveModel::Validations
+    include ActiveModel::Conversion
+
+    def initialize(attributes = {})
+      super
+    end
+
+    def validate!
+      raise ValidationError, errors unless valid?
+    end
+
+    def persisted?
+      false
+    end
+  end
+end

--- a/app/command/execute.rb
+++ b/app/command/execute.rb
@@ -1,0 +1,17 @@
+module Command
+  module Execute
+    def execute(command)
+      command.validate!
+      handler_for(command).call(command)
+    end
+
+    private
+
+    def handler_for(command)
+      {
+        Command::AddAssetToPorfolio => CommandHandler::AddAssetToPortfolio.new
+      }.fetch(command.class)
+    end
+
+  end
+end

--- a/app/command/handler.rb
+++ b/app/command/handler.rb
@@ -1,0 +1,11 @@
+module Command
+  module Handler
+    def with_aggregate(aggregate_class, aggregate_id)
+      stream = "#{aggregate_class.name}$#{aggregate_id}"
+      aggregate = aggregate_class.new(aggregate_id)
+      aggregate = aggregate.load(stream)
+      yield aggregate
+      aggregate.store
+    end
+  end
+end

--- a/app/command/validation_error.rb
+++ b/app/command/validation_error.rb
@@ -1,0 +1,3 @@
+module Command
+  ValidationError = Class.new(StandardError)
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
 require 'rqrcode'
+require 'aggregate_root'
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -22,13 +23,14 @@ Bundler.require(*Rails.groups)
 module MMT
   class Application < Rails::Application
     config.autoload_paths += Dir["#{config.root}/app/**/"]
+    config.event_store = RailsEventStore::Client.new
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end
 
     config.before_initialize do
-      require Rails.root.join 'config', 'initializers', 'magic_money_tree'
+      require config.root.join 'config', 'initializers', 'magic_money_tree'
     end
 
     config.cache_store = :redis_store, {
@@ -38,5 +40,9 @@ module MMT
       # namespace: ENV.fetch('REDIS_NAMESPACE') { Rails.env }
     }
 
+  end
+
+  AggregateRoot.configure do |config|
+    config.default_event_store = Rails.application.config.event_store
   end
 end

--- a/db/migrate/20170806090614_create_event_store_events.rb
+++ b/db/migrate/20170806090614_create_event_store_events.rb
@@ -1,0 +1,16 @@
+class CreateEventStoreEvents < ActiveRecord::Migration[4.2]
+  def change
+    create_table(:event_store_events) do |t|
+      t.string      :stream,      null: false
+      t.string      :event_type,  null: false
+      t.string      :event_id,    null: false
+      t.text        :metadata
+      t.text        :data,        null: false
+      t.datetime    :created_at,  null: false
+    end
+    add_index :event_store_events, :stream
+    add_index :event_store_events, :created_at
+    add_index :event_store_events, :event_type
+    add_index :event_store_events, :event_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,19 @@ ActiveRecord::Schema.define(version: 20171030104608) do
     t.index ["code"], name: "index_coins_on_code", unique: true
   end
 
+  create_table "event_store_events", id: :serial, force: :cascade do |t|
+    t.string "stream", null: false
+    t.string "event_type", null: false
+    t.string "event_id", null: false
+    t.text "metadata"
+    t.text "data", null: false
+    t.datetime "created_at", null: false
+    t.index ["created_at"], name: "index_event_store_events_on_created_at"
+    t.index ["event_id"], name: "index_event_store_events_on_event_id", unique: true
+    t.index ["event_type"], name: "index_event_store_events_on_event_type"
+    t.index ["stream"], name: "index_event_store_events_on_stream"
+  end
+
   create_table "friendly_id_slugs", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "slug", null: false
     t.uuid "sluggable_id", null: false


### PR DESCRIPTION
Implementation of event store using event streams to dictate values of a member's balance and central reserve value as a summed history of all transactions

4 primary actions:
```ruby
Member::Deallocate
Coin::Allocate
Coin::Deallocate
Member::Allocate
```

My logic being that any change in balance of an individual or a coin will never have more than 4 events. Any other events surrounding this, such as `Events::Members::Purchase` or `Events::Members::Withdrawl` are trigger actions for these other events.

The purchase event triggers allocation and deallocation events which append to the relevant Member and Coin streams, adjusting the correct values for each stream.

For any given purchase e.g. Alice buys 5 BTC off the system using her 1000 NEO, actions go in the above order, so the central reserve can never be down, the member always gets their funds deallocated first and allocated last.

Each event stores all quantites as integers. Rates are stored as strings (could change to decimal).

The integer storage I got a bit muddle on but it works, I think there's a better way of doing it as at the moment its a bit of a mess in the code.