### PR TITLE
Fix specs wiping the db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,8 +2,8 @@ default: &default
   adapter: postgresql
   encoding: utf8
   pool: 5
-  username: postgres
-  host: <%= ENV.fetch('DATABASE_URL', 'localhost') %>
+  host: <%= ENV.fetch('DB_HOST', 'localhost') %>
+  username: <%= ENV.fetch("DB_USER", "postgres") %>
   password:
 
 development:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       - bundle:/usr/local/bundle
     command: docker/entrypoint.sh
     environment:
-      DATABASE_URL: db
+      DB_HOST: db
+      DB_USER: postgres
     ports:
       - "3000:80"
 
@@ -40,7 +41,8 @@ services:
       - .:/mmt
       - bundle:/usr/local/bundle
     environment:
-      DATABASE_URL: db
+      DB_HOST: db
+      DB_USER: postgres
       REDIS_HOST: redis
 
 volumes:

--- a/docker/wait-for-postgresql.sh
+++ b/docker/wait-for-postgresql.sh
@@ -5,7 +5,7 @@ set -e
 
 cmd="$@"
 
-until psql -h "${DATABASE_URL}" -U "postgres" -c '\q'; do
+until psql -h "${DB_HOST}" -U "postgres" -c '\q'; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
`DATABASE_URL` overrides the test db settings,
use `DB_HOST` instead (so specs do not wipe the development db)